### PR TITLE
bugfix: correct spelling of argument in a few places

### DIFF
--- a/src/lib/components/BoxControl.svelte
+++ b/src/lib/components/BoxControl.svelte
@@ -171,7 +171,7 @@
 					icon: 'addUp',
 					onclick: () => addSibling(0),
 					disabled: !validFocus,
-					tooltip: 'add arguement above',
+					tooltip: 'add argument above',
 					shortcut: ['option', 'return'],
 					disabledReason
 				},
@@ -179,7 +179,7 @@
 					icon: 'addDown',
 					onclick: () => addSibling(1),
 					disabled: !validFocus,
-					tooltip: 'add arguement below',
+					tooltip: 'add argument below',
 					shortcut: ['return'],
 					disabledReason
 				},

--- a/src/lib/components/scenes/SpacingScene.svelte
+++ b/src/lib/components/scenes/SpacingScene.svelte
@@ -55,7 +55,7 @@
 <div class="top">
 	<ul class="palette-accent">
 		<div class="row1 palette-accent">
-			<FakeBox text="Arguement 1" />
+			<FakeBox text="Argument 1" />
 			<div class="palette-accent-secondary">
 				<FakeBox text="Response 1" below />
 				<div class="addedResponse" bind:this={addedResponse}>
@@ -64,9 +64,9 @@
 			</div>
 		</div>
 		<div bind:this={otherRows} class="otherRows">
-			<FakeBox text="Arguement 2" />
-			<FakeBox text="Arguement 3" />
-			<FakeBox text="Arguement 4" below />
+			<FakeBox text="Argument 2" />
+			<FakeBox text="Argument 3" />
+			<FakeBox text="Argument 4" below />
 		</div>
 	</ul>
 </div>


### PR DESCRIPTION
Just a small PR to fix some spelling errors that someone from our team noticed. 

Not really relevant to this PR, but we are also working on software for Debate. Maybe check out some of our repo's? 

We also took a stab at what a collaborative flow might look like over at [app.arguflow.gg](https://app.arguflow.gg/) which we documented with [docs.arguflow.gg](https://docs.arguflow.gg/). Here is a demo video of that: https://youtu.be/0Y-HTdBtO20 . 

Pretty soon we intend to launch a service similar to debatev.com , but with semantic search. That should be live in a couple of days. I would really like to see if we can integrate it into `debate-flow`! 

We work in public, feel free to join on us on Matrix - https://docs.arguflow.gg/how-to-join-our-matrix - if you're interested in talking more! 