### PR TITLE
Added custom webkit scrollbars and settings for scrollbars

### DIFF
--- a/src/lib/components/Flow.svelte
+++ b/src/lib/components/Flow.svelte
@@ -7,6 +7,7 @@
 	import { focusId } from '$lib/models/focus';
 	import { nodes } from '$lib/models/store';
 	import { addNewEmpty } from '$lib/models/nodeDecorateAction';
+	import { settings } from '$lib/models/settings';
 
 	export let flowId: FlowId;
 	let node: Node<Flow>;
@@ -33,7 +34,7 @@
 
 <div class="top" class:invert={flow.invert} style={`--column-count: ${flow.columns.length};`}>
 	<div class="viewer">
-		<div class="content">
+		<div class="content" class:customScrollbar={settings.data.customScrollbar.value}>
 			<Box id={flowId} />
 		</div>
 		<div class="headers">
@@ -119,7 +120,8 @@
 		padding-top: calc(2.4em + var(--padding));
 		width: calc(var(--column-width) * var(--column-count));
 		height: var(--view-height);
-		overflow: auto;
+		overflow-x: clip;
+		overflow-y: auto;
 		box-sizing: border-box;
 	}
 </style>

--- a/src/lib/components/SavedFlow.svelte
+++ b/src/lib/components/SavedFlow.svelte
@@ -7,6 +7,7 @@
 		downloadSavedNodes
 	} from '$lib/models/autoSave';
 	import { hiddenButtons, savedFlow } from '$lib/models/transition';
+	import { settings } from '$lib/models/settings';
 
 	function prettyDate(date: string) {
 		const today = new Date();
@@ -36,7 +37,7 @@
 </script>
 
 <div class="flow" transition:savedFlow>
-	<div class="infoView">
+	<div class="infoView" class:customScrollbar={settings.data.customScrollbar.value}>
 		<div class="infos">
 			{#each flowData.flowInfos as info}
 				<div

--- a/src/lib/components/SavedFlows.svelte
+++ b/src/lib/components/SavedFlows.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { MAX_SAVED_FLOWS, type SavedNodesDatas } from '$lib/models/autoSave';
+	import { settings } from '$lib/models/settings';
 	import Button from './Button.svelte';
 	import SavedFlow from './SavedFlow.svelte';
 
@@ -26,7 +27,7 @@
 			up to {MAX_SAVED_FLOWS} flows saved in your browser but lost when you clear cookies
 		</p>
 	</div>
-	<div class="view">
+	<div class="view" class:customScrollbar={settings.data.customScrollbar.value}>
 		<div class="flows">
 			{#each sortedSavedFlowsDatas as [key, flowData] (key)}
 				<SavedFlow {flowData} {key} />

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -25,7 +25,7 @@
 
 <div class="top palette-plain">
 	<div class="outline">
-		<div class="outlineScroll">
+		<div class="outlineScroll" class:customScrollbar={settings.data.customScrollbar.value}>
 			<ul>
 				{#each settingsGroups as group, groupIndex}
 					<li class="title">
@@ -48,7 +48,7 @@
 			</ul>
 		</div>
 	</div>
-	<div class="content">
+	<div class="content" class:customScrollbar={settings.data.customScrollbar.value}>
 		<section class="controls">
 			<Button
 				icon="arrowRoundLeft"

--- a/src/lib/components/SideDoc.svelte
+++ b/src/lib/components/SideDoc.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
+	import { settings } from '$lib/models/settings';
 	import { sideDocText } from '$lib/models/store';
 </script>
 
 <div class="document">
-	<textarea class="text" placeholder="type notes here" bind:value={$sideDocText} />
+	<textarea class="text" placeholder="type notes here" bind:value={$sideDocText} class:customScrollbar={settings.data.customScrollbar.value}/>
 </div>
 
 <style>

--- a/src/lib/models/settings.ts
+++ b/src/lib/models/settings.ts
@@ -279,6 +279,25 @@ export const settings: Settings = new Settings({
 			step: 1
 		}
 	},
+	customScrollbar: {
+		name: 'Custom scrollbars',
+		type: 'toggle',
+		value: true,
+		auto: true,
+		info: 'Reload for these changes to take effect'
+	},
+	scrollbarWidth: {
+		name: 'Scrollbar Width',
+		value: 6,
+		auto: 6,
+		type: 'slider',
+		detail: {
+			min: 1,
+			max: 26,
+			step: 1
+		},
+		info: 'Does not work on Firefox'
+	},
 	padding: {
 		name: 'Padding',
 		value: 8,
@@ -387,6 +406,10 @@ export const settingsGroups: SettingsGroup[] = [
 	{
 		name: 'Borders',
 		settings: ['lineWidth', 'borderRadius']
+	},
+	{
+		name: 'Scrollbars',
+		settings: ['scrollbarWidth', 'customScrollbar']
 	},
 	{
 		name: 'Animations',

--- a/src/lib/models/settings.ts
+++ b/src/lib/models/settings.ts
@@ -279,25 +279,6 @@ export const settings: Settings = new Settings({
 			step: 1
 		}
 	},
-	customScrollbar: {
-		name: 'Custom scrollbars',
-		type: 'toggle',
-		value: true,
-		auto: true,
-		info: 'Reload for these changes to take effect'
-	},
-	scrollbarWidth: {
-		name: 'Scrollbar Width',
-		value: 6,
-		auto: 6,
-		type: 'slider',
-		detail: {
-			min: 1,
-			max: 26,
-			step: 1
-		},
-		info: 'Does not work on Firefox'
-	},
 	padding: {
 		name: 'Padding',
 		value: 8,
@@ -366,6 +347,25 @@ export const settings: Settings = new Settings({
 			step: 1
 		}
 	},
+	customScrollbar: {
+		name: 'Custom scrollbars',
+		type: 'toggle',
+		value: false,
+		auto: false,
+		info: 'Reload for these changes to take effect'
+	},
+	customScrollbarWidth: {
+		name: 'Custom scrollbar width',
+		value: 6,
+		auto: 6,
+		type: 'slider',
+		detail: {
+			min: 1,
+			max: 26,
+			step: 1
+		},
+		info: 'Does not work on Firefox'
+	},
 	consistentEnterBehaviour: {
 		name: 'Pressing enter always creates new cell',
 		value: false,
@@ -408,16 +408,16 @@ export const settingsGroups: SettingsGroup[] = [
 		settings: ['lineWidth', 'borderRadius']
 	},
 	{
-		name: 'Scrollbars',
-		settings: ['scrollbarWidth', 'customScrollbar']
-	},
-	{
 		name: 'Animations',
 		settings: ['transitionSpeed', 'useTooltips']
 	},
 	{
 		name: 'Toolbar',
 		settings: ['showUndoRedoButtons', 'showBoxCreationButtons', 'showBoxFormatButtons']
+	},
+	{
+		name: 'Scrollbars',
+		settings: ['customScrollbar', 'customScrollbarWidth']
 	},
 	{ name: 'Controls', settings: ['consistentEnterBehaviour'] }
 ];

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -103,8 +103,8 @@
 			name: 'side-doc-width',
 			unit: 'px'
 		},
-		scrollbarWidth: {
-			name:'scrollbar-width',
+		customScrollbarWidth: {
+			name:'custom-scrollbar-width',
 			unit: 'px'
 		}
 	};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -102,6 +102,10 @@
 		sideDocWidth: {
 			name: 'side-doc-width',
 			unit: 'px'
+		},
+		scrollbarWidth: {
+			name:'scrollbar-width',
+			unit: 'px'
 		}
 	};
 	onDestroy(

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -90,6 +90,7 @@
 		margin: 0;
 		padding: 0;
 		overflow-y: scroll;
+		overflow-x: clip;
 	}
 	main {
 		display: flex;

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -258,6 +258,24 @@
 
 	let switchSpeakers = false;
 
+	// Custom scrollbar/overflow logic
+	onMount(() => { 
+		document.body.classList.add("app");
+	});
+
+	onDestroy(() => {
+		document.body.classList.remove("app");
+		document.body.classList.remove("customScrollbar");
+	});
+
+	$: {
+		if (settings.data.customScrollbar.value) {
+			document.body.classList.add("customScrollbar");
+		} else {
+			document.body.classList.remove("customScrollbar");
+		}
+	}
+
 	// TODO:
 	// add custom background color
 	// add command K
@@ -307,7 +325,7 @@
 					]}
 				/>
 			</div>
-			<div class="tabs">
+			<div class="tabs" class:customScrollbar={settings.data.customScrollbar.value}>
 				<div class="tabScroll">
 					<SortableList list={$nodes.root.children} on:sort={handleSort} let:index>
 						<Tab
@@ -332,7 +350,7 @@
 					<div class="box-control">
 						<BoxControl flowId={$selectedFlowId} />
 					</div>
-					<div class="flow">
+					<div class="flow" class:customScrollbar={settings.data.customScrollbar.value}>
 						<Flow on:focusFlow={focusFlow} flowId={$selectedFlowId} />
 					</div>
 				{/key}
@@ -351,6 +369,10 @@
 </main>
 
 <style>
+	:global(body.app) {
+		overflow-x: auto;
+		overflow-y: clip;
+	}
 	.grid {
 		display: grid;
 		gap: var(--gap);
@@ -419,6 +441,7 @@
 	.flow {
 		width: 100%;
 		overflow-x: auto;
+		overflow-y: clip;
 		background: var(--background);
 		z-index: 0;
 		border-radius: var(--border-radius);

--- a/src/routes/global.css
+++ b/src/routes/global.css
@@ -109,6 +109,10 @@ body {
 	--slider-switch-lightness: 60%;
 
 	--color-screen: hsl(0 0% 0%/ 0.3);
+
+	--scrollbar-background: var(--background-back);
+	--scrollbar-thumb: hsl(0 0% 70%);
+	--scrollbar-thumb-hover: hsl(0 0% 75%);
 }
 body.dark {
 	--background-back: hsl(0 0% 10%);
@@ -155,6 +159,10 @@ body.dark {
 	--slider-switch-lightness: 42%;
 
 	--color-screen: hsl(0 0% 0%/ 0.4);
+
+	--scrollbar-background: var(--background-back);
+	--scrollbar-thumb: hsl(0 0% 50%);
+	--scrollbar-thumb-hover: hsl(0 0% 55%);
 }
 .palette-plain {
 	--this-background: var(--background);
@@ -207,4 +215,26 @@ a:visited {
 a:hover,
 a:active {
 	color: var(--text-accent-select);
+}
+.customScrollbar::-webkit-scrollbar {
+	width: var(--scrollbar-width); 
+	height: var(--scrollbar-width);
+}
+.customScrollbar::-webkit-scrollbar-thumb {
+	background: var(--scrollbar-thumb); 
+	border: 2px solid var(--scrollbar-background);
+}
+.customScrollbar::-webkit-scrollbar-thumb:hover {
+	background: var(--scrollbar-thumb-hover); 
+}
+.customScrollbar::-webkit-scrollbar-track {
+	background: var(--scrollbar-background); 
+}
+
+/* Firefox-specific styles */
+@supports (-moz-appearance: none) {
+	.customScrollbar {
+		scrollbar-width: thin;
+		scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-background);
+	}
 }

--- a/src/routes/global.css
+++ b/src/routes/global.css
@@ -217,8 +217,8 @@ a:active {
 	color: var(--text-accent-select);
 }
 .customScrollbar::-webkit-scrollbar {
-	width: var(--scrollbar-width); 
-	height: var(--scrollbar-width);
+	width: var(--custom-scrollbar-width); 
+	height: var(--custom-scrollbar-width);
 }
 .customScrollbar::-webkit-scrollbar-thumb {
 	background: var(--scrollbar-thumb); 


### PR DESCRIPTION
Hi! Here's a second PR about custom scrollbars.

## Motivation
On Windows machines, scrollbars are wide and can cover a bit of the rightmost column on a flow. In addition, they don't fit with the dark theme. 

## Changes
1) I added custom webkit scrollbars that support thinner and more thematic styles. 
**Note**: I added logic to keep the splash page using default-style scrollbars. However, I did change the overflow rules on the splash page to prevent an x-direction scrollbar from showing up on Windows machines.
2) I added a setting to control the width of the scrollbars as well as a toggle to disable them. 
**Note**: I did not know where to place the settings, so I made a new section. Also, I set the default to having the custom scrollbars on with 6px width (my preference), but feel free to change these. 
3) I changed overflow rules in certain locations to prevent poor scrolling behavior. Previously, in certain cases on Windows and maybe Mac, the nodes in a flow could be scrolled horizontally and become unaligned with the background columns.

## Testing
I hand-tested the scrollbars on Windows Chrome, Windows Edge, Windows Firefox, Mac Chrome, and Mac Safari. All scrollbars seem to be properly replaced, and the new overflow rules seem to prevent poor scrolling behavior without cutting off content. However, as before, the tests were not rigorous, so small problems may have been missed. 

Old browsers will likely fall back to legacy behavior, but their behavior is untested.

The new overflow rules could affect mobile, but this is also untested (I assume very few people are flowing on their phones, though iPads could be a more common use case).

---
As always, let me know what you think. I am happy to edit any changes to your suggestion.