### PR TITLE
Fixed scroll alignment issue

### DIFF
--- a/src/lib/components/Flow.svelte
+++ b/src/lib/components/Flow.svelte
@@ -30,11 +30,18 @@
 		let id = addNewEmpty(flowId, column);
 		$focusId = id;
 	}
+
+	function fixScroll(event: Event) {
+		const el = event.currentTarget as HTMLDivElement;
+		if (el.scrollLeft !== 0) {
+			el.scrollLeft = 0;
+		}
+	}
 </script>
 
 <div class="top" class:invert={flow.invert} style={`--column-count: ${flow.columns.length};`}>
 	<div class="viewer">
-		<div class="content" class:customScrollbar={settings.data.customScrollbar.value}>
+		<div class="content" class:customScrollbar={settings.data.customScrollbar.value} on:scroll={fixScroll}>
 			<Box id={flowId} />
 		</div>
 		<div class="headers">


### PR DESCRIPTION
This addresses a Windows-specific edge case where, despite `overflow-x: clip` in `Flow`, content can still scroll under certain conditions when custom scrollbars are off. The added listener fixes the issue and has been tested on Mac to ensure no side effects. This is purely a Windows-related fix.