### PR TITLE
Mac Safari bad initial scaling fix and a scrolling fix

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -71,10 +71,6 @@
 			name: 'padding',
 			unit: 'px'
 		},
-		fontSize: {
-			name: 'font-size',
-			unit: 'rem'
-		},
 		fontWeight: {
 			name: 'font-weight',
 			unit: ''
@@ -129,6 +125,18 @@
 			}
 		})
 	);
+	onDestroy(
+		settings.subscribe(['fontSize'], function (_key: string) {
+			const remFontSize = settings.data.fontSize.value as number;
+
+			const rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize);
+			const pixelValue = remFontSize * rootFontSize;
+			const roundedPixelValue = Math.round(pixelValue); // Round to nearest px
+			const roundedRemFontSize = roundedPixelValue / rootFontSize;
+
+			document.body.style.setProperty('--font-size', roundedRemFontSize + "rem");
+		})
+	)
 	onDestroy(
 		settings.subscribe(Object.keys(cssVarIndex), function (key: string) {
 			const name = cssVarIndex[key].name;

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -276,6 +276,13 @@
 		}
 	}
 
+	function fixScroll(event: Event) {
+		const el = event.currentTarget as HTMLDivElement;
+		if (el.scrollTop !== 0) {
+			el.scrollTop = 0;
+		}
+	}
+
 	// TODO:
 	// add custom background color
 	// add command K
@@ -350,7 +357,7 @@
 					<div class="box-control">
 						<BoxControl flowId={$selectedFlowId} />
 					</div>
-					<div class="flow" class:customScrollbar={settings.data.customScrollbar.value}>
+					<div class="flow" class:customScrollbar={settings.data.customScrollbar.value} on:scroll={fixScroll}>
 						<Flow on:focusFlow={focusFlow} flowId={$selectedFlowId} />
 					</div>
 				{/key}


### PR DESCRIPTION
Hello. I found the root cause of the weird Safari scaling issue. Certain font sizes in rem create non-pixel perfect values. 0.9 rem (the default font size) happens to be right in between two pixel values which throws Safari off. There are a few options to fix it.

1. Round the rem setting to the nearest value that leads to a pixel perfect font size. The benefit to this is no matter the font size chosen by the user, this problem will not resurface. The downside is that the font size slider in settings does not snap which could confuse users.
2. Change the default font size to a pixel perfect value. For most people who don't change font size, this will fix the issue. However, people may select a value in settings that recreates the issue.
3. Have the slider in settings snap. The benefits are the same as 1 without its downside. However, the problem is that this method requires additional code in `Slider.svelte` to support snapping (the step size needed is not fixed).
4. Change the setting to raw px values. The problem is that this doesn't take into account user's default font size, hurting accessiblity.
5. Leave it as-is. 

I implemented option 1. Let me know if I should swap it out for another, or if I should change anything about the implementation.

Also, I bundled another scrolling fix in this PR. In certain cases, this scrolling fix can create a tiny bit of jitter, but it is better than it getting unaligned forever. The jitter only occurs when the scrolling gets realigned, so it doesn't affect any users with zero-width scroll bars, and also only seems to be present on Mac Safari. These two conditions combined creates a very small group that would experience this.

If you want to see the change, turn on custom scroll bars with a large width (I use ~17). Choose a flow that needs horizontal scrolling (like Congress). Then continue pressing enter to make new cells downward for a while. On the old version, the top might unalign on any browser with non-zero width scroll bars. With the fix, the unalignment doesn't happen, but there is just a moment of slight jitter (if on Mac Safari) which I believe is preferable. I will look into removing this jitter.

Let me know if I should change anything. 