### PR TITLE
Conditional settings and more flow options

### DIFF
--- a/src/lib/components/ColorSelector.svelte
+++ b/src/lib/components/ColorSelector.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import type { Hexcode } from "$lib/models/settings";
+
+  export let value: Hexcode = "#ffffff";
+</script>
+
+<label class="palette-plain">
+  <input type="color" bind:value />
+  <div class="background" style={`--current-selector-color:${value}`}></div>
+</label>
+
+<style>
+  label {
+    margin-left: auto;
+  }
+
+  .background {
+    position: relative;
+    box-sizing: content-box;
+    padding: var(--padding-small);
+    width: calc(var(--button-size) * 2);
+    height: calc(var(--button-size) - 2 * var(--line-width));
+    background-color: var(--current-selector-color);
+    border-radius: var(--border-radius);
+    border: var(--line-width) solid var(--color);
+    transition: filter var(--transition-speed);
+  }
+
+  .background:hover {
+    filter: brightness(1.2);
+  }
+
+  input {
+    visibility: hidden;
+    position: absolute;
+  }
+</style>

--- a/src/lib/components/Setting.svelte
+++ b/src/lib/components/Setting.svelte
@@ -6,6 +6,8 @@
 	import { settings, type Setting } from '$lib/models/settings';
 	import { tweened } from 'svelte/motion';
 	import { onDestroy } from 'svelte';
+	import { settingIn, settingOut } from '$lib/models/transition';
+	import ColorSelector from './ColorSelector.svelte';
 	export let setting: Setting;
 	export let key: string;
 
@@ -41,7 +43,9 @@
 	}
 </script>
 
-<div class="top" bind:this={element} style={`--spotlight:${$spotlight}`}>
+<div class="top" bind:this={element} in:settingIn={{skip: false}} out:settingOut={{skip: false}}>
+	<div class="spotlight" style={`--spotlight:${$spotlight}`}>
+	</div>
 	<span class="above">
 		<div class="titleReset">
 			<h2>{setting.name}</h2>
@@ -58,7 +62,10 @@
 		{#if setting.type == 'toggle'}
 			<Toggle bind:value auto={setting.auto} />
 		{/if}
-		{#if setting.info && setting.type != 'toggle'}
+		{#if setting.type == 'color'}
+			<ColorSelector bind:value />
+		{/if}
+		{#if setting.info && setting.type != 'toggle' && setting.type != 'color'}
 			<p class="info">{setting.info}</p>
 		{/if}
 	</span>
@@ -74,7 +81,7 @@
 	{#if setting.type == 'slider'}
 		<Slider bind:value auto={setting.auto} detail={setting.detail} />
 	{/if}
-	{#if setting.info && setting.type == 'toggle'}
+	{#if setting.info && (setting.type == 'toggle' || setting.type == 'color')}
 		<p class="info">{setting.info}</p>
 	{/if}
 </div>
@@ -89,16 +96,24 @@
 		width: 100%;
 		box-sizing: border-box;
 	}
-
+	.spotlight {
+		background-color: var(--this-background-indent);
+		opacity: var(--spotlight);
+		border-radius: var(--border-radius);
+		position: absolute;
+		height: 100%;
+		width: 100%;
+		top: calc(-1 * var(--padding)/2);
+		left: calc(-1 * var(--padding)/2);
+	}
 	.above {
 		position: relative;
 		display: flex;
 		flex-direction: row;
 		gap: 1em;
-		height: var(--button-size);
 		align-items: center;
 		padding-bottom: var(--padding);
-		height: 100%;
+		height: auto;
 	}
 	.above h2 {
 		width: max-content;

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -98,13 +98,13 @@
 		</section>
 		<section class="controls">
 			<Button
-				icon="dots"
+				icon="upload"
 				text="import settings"
 				tooltip="import settings from file"
 				on:click={() => openUploadDialog()}
 			/>
 			<Button
-				icon="dots"
+				icon="download"
 				text="export settings"
 				tooltip="export settings to file"
 				on:click={() => downloadSettingsJson()}

--- a/src/lib/models/autoSave.ts
+++ b/src/lib/models/autoSave.ts
@@ -67,8 +67,10 @@ export function getSavedNodesDatas(): SavedNodesDatas {
 
 export function loadSavedNodes(key: NodeKey, modifyOriginal = false) {
 	const raw = localStorage.getItem(key);
+	if (!raw) return;
+	const nodesObj = JSON.parse(raw);
 	if (raw === null) return [];
-	const newNodes: Nodes = loadNodes(raw);
+	const newNodes: Nodes = loadNodes(nodesObj);
 	replaceNodes(newNodes);
 	if (modifyOriginal) {
 		flowKey = key;

--- a/src/lib/models/debateStyle.ts
+++ b/src/lib/models/debateStyle.ts
@@ -15,8 +15,41 @@ export const debateStyleMap = [
 
 export type DebateStyleKey = (typeof debateStyleMap)[number];
 
-export function currentDebateStyle(): DebateStyle {
+export const debateTemplateMap = [
+	'primary',
+	'secondary',
+	'tertiary',
+	'quaternary'
+] as const;
+
+export type DebateTemplateKey = (typeof debateTemplateMap)[number];
+
+export function getDebateStyle(): DebateStyle {
 	return debateStyles[debateStyleMap[settings.data.debateStyle.value as number]];
+}
+export function getAllDebateStyleFlows(): DebateStyleFlow[] {
+	let debateStyle = getDebateStyle();
+	if (debateStyle.alternativeFlowSelectorSettingName && debateStyle.alternativeFlowSelectorSettingName in settings.data) {
+		const subflow = debateStyle[`alternativeFlows${settings.data[debateStyle.alternativeFlowSelectorSettingName].value as number}`];
+		if (subflow) return subflow;
+	}
+	return debateStyle.flows;
+}
+export function getDebateStyleFlow(flowPostion: DebateTemplateKey | number): DebateStyleFlow | null {
+	let debateFlows = getAllDebateStyleFlows();
+
+	let index;
+	if (typeof flowPostion == "number") {
+		index = flowPostion;
+	} else {
+		index = debateTemplateMap.indexOf(flowPostion);
+	}
+
+	if (index === -1) {
+		return null;
+	}
+
+	return debateFlows[index] || null;
 }
 
 export type DebateStyleFlow = {
@@ -27,25 +60,29 @@ export type DebateStyleFlow = {
 	starterBoxes?: string[];
 };
 export type DebateStyle = {
-	primary: DebateStyleFlow;
-	secondary?: DebateStyleFlow;
+	flows: DebateStyleFlow[];
+	alternativeFlowSelectorSettingName?: string;
 	timerSpeeches: TimerSpeech[];
 	prepTime?: number;
+} & {
+	[K in `alternativeFlows${number}`]?: DebateStyleFlow[];
 };
 export const debateStyles: {
 	[key in DebateStyleKey]: DebateStyle;
 } = {
 	policy: {
-		primary: {
-			name: 'aff',
-			columns: ['1AC', '1NC', '2AC', '2NC/1NR', '1AR', '2NR', '2AR'],
-			invert: false
-		},
-		secondary: {
-			name: 'neg',
-			columns: ['1NC', '2AC', '2NC/1NR', '1AR', '2NR', '2AR'],
-			invert: true
-		},
+		flows: [
+			{
+				name: 'aff',
+				columns: ['1AC', '1NC', '2AC', '2NC/1NR', '1AR', '2NR', '2AR'],
+				invert: false
+			},
+			{
+				name: 'neg',
+				columns: ['1NC', '2AC', '2NC/1NR', '1AR', '2NR', '2AR'],
+				invert: true
+			}
+		],
 		timerSpeeches: [
 			{
 				name: '1AC',
@@ -111,18 +148,20 @@ export const debateStyles: {
 		prepTime: 8 * 60 * 1000
 	},
 	publicForum: {
-		primary: {
-			name: 'aff',
-			columns: ['AC', 'NC', 'AR', 'NR', 'AS', 'NS', 'AFF', 'NFF'],
-			columnsSwitch: ['AC', 'NR', 'AR', 'NS', 'AS', 'NFF', 'AFF'],
-			invert: false
-		},
-		secondary: {
-			name: 'neg',
-			columns: ['NC', 'AR', 'NR', 'AS', 'NS', 'AFF', 'NFF'],
-			columnsSwitch: ['NC', 'AC', 'NR', 'AR', 'NS', 'AS', 'NFF', 'AFF'],
-			invert: true
-		},
+		flows: [
+			{
+				name: 'aff',
+				columns: ['AC', 'NC', 'AR', 'NR', 'AS', 'NS', 'AFF', 'NFF'],
+				columnsSwitch: ['AC', 'NR', 'AR', 'NS', 'AS', 'NFF', 'AFF'],
+				invert: false
+			},
+			{
+				name: 'neg',
+				columns: ['NC', 'AR', 'NR', 'AS', 'NS', 'AFF', 'NFF'],
+				columnsSwitch: ['NC', 'AC', 'NR', 'AR', 'NS', 'AS', 'NFF', 'AFF'],
+				invert: true
+			}
+		],
 		timerSpeeches: [
 			{
 				name: 'AC',
@@ -183,18 +222,47 @@ export const debateStyles: {
 		prepTime: 4 * 60 * 1000
 	},
 	lincolnDouglas: {
-		primary: {
-			name: 'aff',
-			columns: ['AC', 'NC', '1AR', 'NR', '2AR'],
-			starterBoxes: ['value', 'criterion'],
-			invert: false
-		},
-		secondary: {
-			name: 'neg',
-			columns: ['NC', '1AR', 'NR', '2AR'],
-			starterBoxes: ['value', 'criterion'],
-			invert: true
-		},
+		flows: [
+			{
+				name: 'aff',
+				columns: ['AC', 'NR', '1AR', '2NR', '2AR'],
+				starterBoxes: ["Value", "Criterion"],
+				invert: false
+			},
+			{
+				name: 'neg',
+				columns: ['NC', '1AR', '2NR', '2AR'],
+				starterBoxes: ["Value", "Criterion"],
+				invert: true
+			},
+		],
+		alternativeFlowSelectorSettingName: "LDSubstyle",
+		alternativeFlows1: [
+			{
+				name: 'aff',
+				columns: ['AC', 'NR', '1AR', '2NR', '2AR'],
+				starterBoxes: ["type here"],
+				invert: false
+			},
+			{
+				name: 'neg',
+				columns: ['NC', '1AR', '2NR', '2AR'],
+				starterBoxes: ["type here"],
+				invert: true
+			},
+			{
+				name: '1ar',
+				columns: ['1AR', '2NR', '2AR'],
+				starterBoxes: ["type here"],
+				invert: false
+			},
+			{
+				name: '2nr',
+				columns: ['2NR', '2AR'],
+				starterBoxes: ["type here"],
+				invert: true
+			}
+		],
 		timerSpeeches: [
 			{
 				name: 'AC',
@@ -235,64 +303,66 @@ export const debateStyles: {
 		prepTime: 4 * 60 * 1000
 	},
 	congress: {
-		primary: {
-			name: 'bill',
-			columns: [
-				'1A',
-				'Q/1N',
-				'Q/2A',
-				'Q/2N',
-				'Q/3A',
-				'Q/3N',
-				'Q/4A',
-				'Q/4N',
-				'Q/5A',
-				'Q/5N',
-				'Q/6A',
-				'Q/6N',
-				'Q/7A',
-				'Q/7N',
-				'Q/8A',
-				'Q/8N',
-				'Q/9A',
-				'Q/9N',
-				'Q/10A',
-				'Q/10N',
-				'Q/11A',
-				'Q/11N',
-				'Q/12A',
-				'Q/12N',
-				'Q/13A',
-				'Q/13N',
-				'Q/14A',
-				'Q/14N',
-				'Q/15A',
-				'Q/15N',
-				'Q/16A',
-				'Q/16N',
-				'Q/17A',
-				'Q/17N',
-				'Q/18A',
-				'Q/18N',
-				'Q/19A',
-				'Q/19N',
-				'Q/20A',
-				'Q/20N',
-				'Q/20A',
-				'Q/20N',
-				'Q/21A',
-				'Q/21N',
-				'Q/22A',
-				'Q/22N',
-				'Q/23A',
-				'Q/23N',
-				'Q/24A',
-				'Q/24N',
-				'Q/25A',
-				'Q/25N'
-			],
-			invert: false
-		},
+		flows: [
+			{
+				name: 'bill',
+				columns: [
+					'1A',
+					'Q/1N',
+					'Q/2A',
+					'Q/2N',
+					'Q/3A',
+					'Q/3N',
+					'Q/4A',
+					'Q/4N',
+					'Q/5A',
+					'Q/5N',
+					'Q/6A',
+					'Q/6N',
+					'Q/7A',
+					'Q/7N',
+					'Q/8A',
+					'Q/8N',
+					'Q/9A',
+					'Q/9N',
+					'Q/10A',
+					'Q/10N',
+					'Q/11A',
+					'Q/11N',
+					'Q/12A',
+					'Q/12N',
+					'Q/13A',
+					'Q/13N',
+					'Q/14A',
+					'Q/14N',
+					'Q/15A',
+					'Q/15N',
+					'Q/16A',
+					'Q/16N',
+					'Q/17A',
+					'Q/17N',
+					'Q/18A',
+					'Q/18N',
+					'Q/19A',
+					'Q/19N',
+					'Q/20A',
+					'Q/20N',
+					'Q/20A',
+					'Q/20N',
+					'Q/21A',
+					'Q/21N',
+					'Q/22A',
+					'Q/22N',
+					'Q/23A',
+					'Q/23N',
+					'Q/24A',
+					'Q/24N',
+					'Q/25A',
+					'Q/25N'
+				],
+				invert: false
+			},
+		],
 		timerSpeeches: [
 			{
 				name: 'speech',
@@ -302,16 +372,18 @@ export const debateStyles: {
 		]
 	},
 	worldSchools: {
-		primary: {
-			name: 'prop',
-			columns: ['P1', 'O1', 'P2', 'O2', 'PW', 'OW', 'OR', 'PR'],
-			invert: false
-		},
-		secondary: {
-			name: 'opp',
-			columns: ['O1', 'P2', 'O2', 'PW', 'OW', 'OR', 'PR'],
-			invert: true
-		},
+		flows: [
+			{
+				name: 'prop',
+				columns: ['P1', 'O1', 'P2', 'O2', 'PW', 'OW', 'OR', 'PR'],
+				invert: false
+			},
+			{
+				name: 'opp',
+				columns: ['O1', 'P2', 'O2', 'PW', 'OW', 'OR', 'PR'],
+				invert: true
+			},
+		],
 		timerSpeeches: [
 			{
 				name: 'P1',
@@ -356,16 +428,18 @@ export const debateStyles: {
 		]
 	},
 	bigQuestions: {
-		primary: {
+		flows: [
+			{
 			name: 'aff',
 			columns: ['AC', 'NC', 'ARb', 'NRb', 'A3', 'N3', 'ARt', 'NRt'],
 			invert: false
-		},
-		secondary: {
-			name: 'neg',
-			columns: ['NC', 'ARb', 'NRb', 'A3', 'N3', 'ARt', 'NRt'],
-			invert: true
-		},
+			},
+			{
+				name: 'neg',
+				columns: ['NC', 'ARb', 'NRb', 'A3', 'N3', 'ARt', 'NRt'],
+				invert: true
+			}
+		],
 		timerSpeeches: [
 			{
 				name: 'AC',
@@ -421,16 +495,18 @@ export const debateStyles: {
 		prepTime: 3 * 60 * 1000
 	},
 	nofSpar: {
-		primary: {
-			name: 'pro',
-			columns: ['PC', 'CC', 'PR', 'CR'],
-			invert: false
-		},
-		secondary: {
-			name: 'con',
-			columns: ['CC', 'PR', 'CR'],
-			invert: true
-		},
+		flows: [
+			{
+				name: 'pro',
+				columns: ['PC', 'CC', 'PR', 'CR'],
+				invert: false
+			},
+			{
+				name: 'con',
+				columns: ['CC', 'PR', 'CR'],
+				invert: true
+			},
+		],
 		timerSpeeches: [
 			{
 				name: 'PREP',
@@ -465,16 +541,18 @@ export const debateStyles: {
 		]
 	},
 	parli: {
-		primary: {
-			name: 'pro',
-			columns: ['1PC', '1OC', '2PC', '2OC/OR', 'PR'],
-			invert: false
-		},
-		secondary: {
-			name: 'opp',
-			columns: ['1OC', '2PC', '2OC/OR', 'PR'],
-			invert: true
-		},
+		flows: [
+			{
+				name: 'pro',
+				columns: ['1PC', '1OC', '2PC', '2OC/OR', 'PR'],
+				invert: false
+			},
+			{
+				name: 'opp',
+				columns: ['1OC', '2PC', '2OC/OR', 'PR'],
+				invert: true
+			}
+		],
 		timerSpeeches: [
 			{
 				name: '1PC',
@@ -509,16 +587,18 @@ export const debateStyles: {
 		]
 	},
 	classic: {
-		primary: {
-			name: 'aff',
-			columns: ['AC', 'NC/1NR', '1AR', '2NR', '2AR', 'NS', 'AS'],
-			invert: false
-		},
-		secondary: {
-			name: 'neg',
-			columns: ['NC/1NR', '1AR', '2NR', '2AR', 'AS', 'NS'],
-			invert: true
-		},
+		flows: [
+			{
+				name: 'aff',
+				columns: ['AC', 'NC/1NR', '1AR', '2NR', '2AR', 'NS', 'AS'],
+				invert: false
+			},
+			{
+				name: 'neg',
+				columns: ['NC/1NR', '1AR', '2NR', '2AR', 'AS', 'NS'],
+				invert: true
+			}
+		],
 		timerSpeeches: [
 			{
 				name: 'AC',

--- a/src/lib/models/settings.ts
+++ b/src/lib/models/settings.ts
@@ -202,8 +202,8 @@ export const settings: Settings = new Settings({
 	customBackgroundBack: {
 		name: 'Back background',
 		type: 'color',
-		value: "#01020e",
-		auto: "#01020e",
+		value: "#1a1a1a",
+		auto: "#1a1a1a",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -211,8 +211,8 @@ export const settings: Settings = new Settings({
 	customBackground: {
 		name: 'Background',
 		type: 'color',
-		value: "#010318",
-		auto: "#010318",
+		value: "#292929",
+		auto: "#292929",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -220,8 +220,8 @@ export const settings: Settings = new Settings({
 	customBackgroundIndent: {
 		name: 'Highlighted background',
 		type: 'color',
-		value: "#020531",
-		auto: "#020531",
+		value: "#3d3d3d",
+		auto: "#3d3d3d",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -229,8 +229,8 @@ export const settings: Settings = new Settings({
 	customBackgroundActive: {
 		name: 'Clicked background',
 		type: 'color',
-		value: "#050848",
-		auto: "#050848",
+		value: "#4d4d4d",
+		auto: "#4d4d4d",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -238,8 +238,8 @@ export const settings: Settings = new Settings({
 	customBackgroundSecondary: {
 		name: 'Background',
 		type: 'color',
-		value: "#020527",
-		auto: "#020527",
+		value: "#2e2e2e",
+		auto: "#2e2e2e",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -247,8 +247,8 @@ export const settings: Settings = new Settings({
 	customBackgroundSecondaryIndent: {
 		name: 'Highlighted background',
 		type: 'color',
-		value: "#050748",
-		auto: "#050748",
+		value: "#474747",
+		auto: "#474747",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -256,8 +256,8 @@ export const settings: Settings = new Settings({
 	customBackgroundSecondaryActive: {
 		name: 'Clicked background',
 		type: 'color',
-		value: "#080c6d",
-		auto: "#080c6d",
+		value: "#374143",
+		auto: "#374143",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -265,8 +265,8 @@ export const settings: Settings = new Settings({
 	customBackgroundAccentIndent: {
 		name: 'Accent',
 		type: 'color',
-		value: "#030531",
-		auto: "#030531",
+		value: "#3d565c",
+		auto: "#3d565c",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -274,8 +274,8 @@ export const settings: Settings = new Settings({
 	customBackgroundAccentActive: {
 		name: 'Clicked accent',
 		type: 'color',
-		value: "#050848",
-		auto: "#050848",
+		value: "#3d565c",
+		auto: "#3d565c",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -283,8 +283,8 @@ export const settings: Settings = new Settings({
 	customBackgroundAccentSecondaryIndent: {
 		name: 'Accent',
 		type: 'color',
-		value: "#050748",
-		auto: "#050748",
+		value: "#373737",
+		auto: "#373737",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -292,8 +292,8 @@ export const settings: Settings = new Settings({
 	customBackgroundAccentSecondaryActive: {
 		name: 'Clicked accent',
 		type: 'color',
-		value: "#080c6d",
-		auto: "#080c6d",
+		value: "#3d3d3d",
+		auto: "#3d3d3d",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -301,8 +301,8 @@ export const settings: Settings = new Settings({
 	customText: {
 		name: 'Text',
 		type: 'color',
-		value: "#ffffff",
-		auto: "#ffffff",
+		value: "#cccccc",
+		auto: "#cccccc",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -310,8 +310,8 @@ export const settings: Settings = new Settings({
 	customTextSelect: {
 		name: 'Selection',
 		type: 'color',
-		value: "#917aff",
-		auto: "#917aff",
+		value: "#4d4d4d",
+		auto: "#4d4d4d",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -319,8 +319,8 @@ export const settings: Settings = new Settings({
 	customTextWeak: {
 		name: 'Weak text',
 		type: 'color',
-		value: "#ffffff",
-		auto: "#ffffff",
+		value: "#808080",
+		auto: "#808080",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -328,8 +328,8 @@ export const settings: Settings = new Settings({
 	customTextAccent: {
 		name: 'Aff text',
 		type: 'color',
-		value: "#adc7f0",
-		auto: "#adc7f0",
+		value: "#addeeb",
+		auto: "#addeeb",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -337,8 +337,8 @@ export const settings: Settings = new Settings({
 	customTextAccentSelect: {
 		name: 'Aff selection',
 		type: 'color',
-		value: "#917aff",
-		auto: "#917aff",
+		value: "#0b4f60",
+		auto: "#0b4f60",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -346,8 +346,8 @@ export const settings: Settings = new Settings({
 	customTextAccentWeak: {
 		name: 'Aff weak text',
 		type: 'color',
-		value: "#917aff",
-		auto: "#917aff",
+		value: "#6c8b93",
+		auto: "#6c8b93",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -355,8 +355,8 @@ export const settings: Settings = new Settings({
 	customTextAccentSecondary: {
 		name: 'Neg text',
 		type: 'color',
-		value: "#e9d6ff",
-		auto: "#e9d6ff",
+		value: "#ebc8ad",
+		auto: "#ebc8ad",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -364,8 +364,8 @@ export const settings: Settings = new Settings({
 	customTextAccentSecondarySelect: {
 		name: 'Neg selection',
 		type: 'color',
-		value: "#ffffff",
-		auto: "#ffffff",
+		value: "#60300b",
+		auto: "#60300b",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -373,8 +373,8 @@ export const settings: Settings = new Settings({
 	customTextAccentSecondaryWeak: {
 		name: 'Weak neg text',
 		type: 'color',
-		value: "#ffffff",
-		auto: "#ffffff",
+		value: "#937d6c",
+		auto: "#937d6c",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -382,8 +382,8 @@ export const settings: Settings = new Settings({
 	customColor: {
 		name: 'Selected lines',
 		type: 'color',
-		value: "#3e46ac",
-		auto: "#3e46ac",
+		value: "#6b6b6b",
+		auto: "#6b6b6b",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -391,8 +391,8 @@ export const settings: Settings = new Settings({
 	customColorFade: {
 		name: 'Unselected Lines',
 		type: 'color',
-		value: "#150354",
-		auto: "#150354",
+		value: "#525252",
+		auto: "#525252",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -400,8 +400,8 @@ export const settings: Settings = new Settings({
 	customColorAccent: {
 		name: 'Aff selected lines',
 		type: 'color',
-		value: "#3f46ac",
-		auto: "#3f46ac",
+		value: "#408596",
+		auto: "#408596",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -409,8 +409,8 @@ export const settings: Settings = new Settings({
 	customColorAccentFade: {
 		name: 'Aff highlighted lines',
 		type: 'color',
-		value: "#180363",
-		auto: "#180363",
+		value: "#3d5e66",
+		auto: "#3d5e66",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -418,8 +418,8 @@ export const settings: Settings = new Settings({
 	customColorAccentSecondary: {
 		name: 'Neg selected lines',
 		type: 'color',
-		value: "#3f46ac",
-		auto: "#3f46ac",
+		value: "#966540",
+		auto: "#966540",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -427,8 +427,8 @@ export const settings: Settings = new Settings({
 	customColorAccentSecondaryFade: {
 		name: 'Neg highlighted lines',
 		type: 'color',
-		value: "#1e047c",
-		auto: "#1e047c",
+		value: "#664f3d",
+		auto: "#664f3d",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		}
@@ -436,8 +436,8 @@ export const settings: Settings = new Settings({
 	customScrollbarThumb: {
 		name: 'Scrollbar thumb',
 		type: 'color',
-		value: "#0a093e",
-		auto: "#0a093e",
+		value: "#808080",
+		auto: "#808080",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		},
@@ -446,8 +446,8 @@ export const settings: Settings = new Settings({
 	customScrollbarThumbHover: {
 		name: 'Hovered scrollbar thumb',
 		type: 'color',
-		value: "#101350",
-		auto: "#101350",
+		value: "#8c8c8c",
+		auto: "#8c8c8c",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		},
@@ -456,8 +456,8 @@ export const settings: Settings = new Settings({
 	customScrollbarBackground: {
 		name: 'Scrollbar background',
 		type: 'color',
-		value: "#04031c",
-		auto: "#04031c",
+		value: "#1a1a1a",
+		auto: "#1a1a1a",
 		visibilityCondition: () => {
 			return settings.data.colorTheme.value == 3;
 		},

--- a/src/lib/models/transition.ts
+++ b/src/lib/models/transition.ts
@@ -302,3 +302,122 @@ export function instructionOut(node: HTMLElement, { reverse }: { reverse: boolea
 		}
 	};
 }
+
+export function settingIn(node: HTMLElement, { skip }: { skip: boolean }) {
+	if (skip || settings.data.transitionSpeed.value as number === 0) {
+		return {
+			duration: 0,
+			css: () => ''
+		};
+	}
+	const h = node.clientHeight;
+
+	return {
+		duration: settings.data.transitionSpeed.value as number,
+		css: (t: number) => {
+			const eased = quadOut(t);
+
+			return `
+        height: calc(${eased * h}px);
+        overflow: visible;
+        clip-path: inset(${(1 - eased) * h - 2}px 0 -${h}px 0);
+        transform: translateY(calc(${(1 - eased) * -h}px));
+		padding-bottom: calc(var(--padding) * ${eased});
+		padding-top: calc(var(--padding) * ${eased});
+        `;
+		}
+	};
+}
+
+export function settingOut(node: HTMLElement, { skip }: { skip: boolean }) {
+	// don't do transition if skip
+	if (skip || settings.data.transitionSpeed.value as number === 0) {
+		return {
+			duration: 0,
+			css: () => ''
+		};
+	}
+	const h = node.clientHeight;
+	return {
+		duration: settings.data.transitionSpeed.value as number,
+		css: (t: number) => {
+			const eased = quadOut(t);
+			return `
+        height: ${eased * h}px;
+        overflow: visible;
+        clip-path: inset(${(1 - eased) * h - 2}px 0 -${h}px 0);
+        transform: translateY(calc(${(1 - eased) * -h}px));
+		padding-bottom: calc(var(--padding) * ${eased});
+		padding-top: calc(var(--padding) * ${eased});
+        `;
+		}
+	};
+}
+
+export function settingScrollerIn(node: HTMLElement, { skip }: { skip: boolean }) {
+	// don't do transition if skip
+	if (skip || settings.data.transitionSpeed.value as number === 0) {
+		return {
+			duration: 0,
+			css: () => ''
+		};
+	}
+	const h = node.clientHeight;
+	return {
+		duration: settings.data.transitionSpeed.value as number,
+		css: (t: number) => {
+			const eased = quadOut(t);
+			return `
+        height: ${eased * h}px;
+        overflow: visible;
+        clip-path: inset(${(1 - eased) * h - 2}px 0 -${h}px 0);
+        transform: translateY(calc(${(1 - eased) * -h}px));
+        `;
+		}
+	};
+}
+
+export function settingScrollerOut(node: HTMLElement, { skip }: { skip: boolean }) {
+	// don't do transition if skip
+	if (skip || settings.data.transitionSpeed.value as number === 0) {
+		return {
+			duration: 0,
+			css: () => ''
+		};
+	}
+	const h = node.clientHeight;
+	return {
+		duration: settings.data.transitionSpeed.value as number,
+		css: (t: number) => {
+			const eased = quadOut(t);
+			return `
+        height: ${eased * h}px;
+        overflow: visible;
+        clip-path: inset(${(1 - eased) * h - 2}px 0 -${h}px 0);
+        transform: translateY(calc(${(1 - eased) * -h}px));
+        `;
+		}
+	};
+}
+
+export function settingTitleInOut(node: HTMLElement, { skip }: { skip: boolean }) {
+	if (skip || settings.data.transitionSpeed.value as number === 0) {
+		return {
+			duration: 0,
+			css: () => ''
+		};
+	}
+	const h = node.clientHeight;
+	return {
+		duration: settings.data.transitionSpeed.value as number,
+		css: (t: number) => {
+			const eased = quadOut(t);
+			return `
+        height: ${eased * h}px;
+        overflow: visible;
+        clip-path: inset(${(1 - eased) * h - 2}px 0 -${h}px 0);
+        transform: translateY(calc(${(1 - eased) * -h}px));
+        `;
+		}
+	};
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -38,9 +38,15 @@
 		settings.subscribe(['colorTheme'], function () {
 			if (settings.data.colorTheme.value == 1) {
 				document.body.classList.remove('dark');
+				document.body.classList.remove('custom');
 			} else if (settings.data.colorTheme.value == 2) {
 				document.body.classList.add('dark');
+				document.body.classList.remove('custom');
+			} else if (settings.data.colorTheme.value == 3) {
+				document.body.classList.remove('dark');
+				document.body.classList.add('custom');
 			} else {
+				document.body.classList.remove('custom');
 				updateColorTheme();
 			}
 		})
@@ -102,6 +108,122 @@
 		customScrollbarWidth: {
 			name:'custom-scrollbar-width',
 			unit: 'px'
+		},
+		customBackgroundBack: {
+			name:'custom-background-back',
+			unit: ''
+		},
+		customBackground: {
+			name:'custom-background',
+			unit: ''
+		},
+		customBackgroundIndent: {
+			name:'custom-background-indent',
+			unit: ''
+		},
+		customBackgroundActive: {
+			name:'custom-background-active',
+			unit: ''
+		},
+		customBackgroundSecondary: {
+			name:'custom-background-secondary',
+			unit: ''
+		},
+		customBackgroundSecondaryIndent: {
+			name:'custom-background-secondary-indent',
+			unit: ''
+		},
+		customBackgroundSecondaryActive: {
+			name:'custom-background-secondary-active',
+			unit: ''
+		},
+		customBackgroundAccentIndent: {
+			name:'custom-background-accent-indent',
+			unit: ''
+		},
+		customBackgroundAccentActive: {
+			name:'custom-background-accent-active',
+			unit: ''
+		},
+		customBackgroundAccentSecondaryIndent: {
+			name:'custom-background-accent-secondary-indent',
+			unit: ''
+		},
+		customBackgroundAccentSecondaryActive: {
+			name:'custom-background-accent-secondary-active',
+			unit: ''
+		},
+		customText: {
+			name:'custom-text',
+			unit: ''
+		},
+		customTextSelect: {
+			name:'custom-text-select',
+			unit: ''
+		},
+		customTextWeak: {
+			name:'custom-text-weak',
+			unit: ''
+		},
+		customTextAccent: {
+			name:'custom-text-accent',
+			unit: ''
+		},
+		customTextAccentSelect: {
+			name:'custom-text-accent-select',
+			unit: ''
+		},
+		customTextAccentWeak: {
+			name:'custom-background-weak',
+			unit: ''
+		},
+		customTextAccentSecondary: {
+			name:'custom-text-accent-secondary',
+			unit: ''
+		},
+		customTextAccentSecondarySelect: {
+			name:'custom-text-accent-secondary-select',
+			unit: ''
+		},
+		customTextAccentSecondaryWeak: {
+			name:'custom-text-accent-secondary-weak',
+			unit: ''
+		},
+		customColor: {
+			name:'custom-color',
+			unit: ''
+		},
+		customColorFade: {
+			name:'custom-color-fade',
+			unit: ''
+		},
+		customColorAccent: {
+			name:'custom-color-accent',
+			unit: ''
+		},
+		customColorAccentFade: {
+			name:'custom-color-accent-fade',
+			unit: ''
+		},
+		customColorAccentSecondary: {
+			name:'custom-color-accent-secondary',
+			unit: ''
+		},
+		customColorAccentSecondaryFade: {
+			name:'custom-color-accent-secondary-fade',
+			unit: ''
+		},
+		customScrollbarThumb: {
+			name:'custom-scrollbar-thumb',
+			unit: ''
+		},
+		customScrollbarThumbHover: {
+			name:'custom-scrollbar-thumb-hover',
+			unit: ''
+		},
+		customScrollbarBackground: {
+			name:'custom-scrollbar-background',
+			unit: ''
 		}
 	};
 	onDestroy(

--- a/src/routes/global.css
+++ b/src/routes/global.css
@@ -164,6 +164,56 @@ body.dark {
 	--scrollbar-thumb: hsl(0 0% 50%);
 	--scrollbar-thumb-hover: hsl(0 0% 55%);
 }
+body.custom {
+	--background-back: var(--custom-background-back);
+
+	--background: var(--custom-background);
+	--background-indent: var(--custom-background-indent);
+	--background-active: var(--custom-background-active);
+
+	--background-secondary: var(--custom-background-secondary);
+	--background-secondary-indent: var(--custom-background-secondary-indent);
+	--background-secondary-active: var(--custom-background-secondary-active);
+
+	--background-accent-indent: var(--custom-background-accent-indent);
+	--background-accent-active: var(--custom-background-accent-active);
+
+	--background-accent-secondary-indent: var(--custom-background-accent-secondary-indent);
+	--background-accent-secondary-active: var(--custom-background-accent-secondary-active);
+
+	--text: var(--custom-text);
+	--text-select: var(--custom-text-select);
+	--text-weak: var(--custom-text-weak);
+	--text-error: hsl(0, 100%, 70%);
+
+	--text-accent: var(--custom-text-accent);
+	--text-accent-select: var(--custom-text-accent-select);
+	--text-accent-weak: var(--custom-text-accent-weak);
+
+	--text-accent-secondary: var(--custom-text-accent-secondary);
+	--text-accent-secondary-select: var(--custom-text-accent-secondary-select);
+	--text-accent-secondary-weak: var(--custom-text-accent-secondary-weak);
+
+	--color: var(--custom-color);
+	--color-fade: var(--custom-color-fade);
+
+	--color-accent: var(--custom-color-accent);
+	--color-accent-fade: var(--custom-color-accent-fade);
+
+	--color-accent-secondary: var(--custom-color-accent-secondary);
+	--color-accent-secondary-fade: var(--custom-color-accent-secondary-fade);
+
+	--slider-lightness: 24%;
+	--slider-lightness-hover: 30%;
+	--slider-saturation: 20%;
+	--slider-switch-lightness: 42%;
+
+	--color-screen: hsl(0 0% 0%/ 0.4);
+
+	--scrollbar-background: var(--custom-scrollbar-background);
+	--scrollbar-thumb: var(--custom-scrollbar-thumb);
+	--scrollbar-thumb-hover: var(--custom-scrollbar-thumb-hover);
+}
 .palette-plain {
 	--this-background: var(--background);
 	--this-background-indent: var(--background-indent);


### PR DESCRIPTION
Hi! Here is one more PR for your consideration. 

This PR is a significant rewrite of the flow templating system and the settings system.

## Motivations

1. In higher levels of LD debate, more than two flow types are needed. The ability to start a flow from the 1AR or 2NR are critical. 
2. Custom themes can be nice for advanced users.

## High Level Changes

1. Flow templates are stored and rendered in a more modular fashion. Unlimited flow templates can be specified per activity. Ex. LD debate now has options for making a new flow from the Aff, Neg, 1AR, and 2NR. 
2. Each activity can have multiple alternative flow styles which can be chosen from a setting (the setting has to be created separately and the name specified in the flow template data structure). Ex. LD debate has the same behavior as before by default, but can be changed into TOC circuit mode. 
3. Settings visibility conditions were added to allow for more customizability without cluttering the settings panel too much.
4. The option to create a custom theme was added to the settings. The custom theme settings are hidden unless "custom theme" is selected.
5. Importing and exporting settings was added.
6. The method of parsing saved node files and saved settings files was changed for easier logic flow. 
7. Various other small changes and fixes.

## Testing

I have had the final version of this PR for a little while, and have tested it quite a bit. Of course, my testing is not exhaustive. However, I have found no significant bugs with the added code. 

There is a bug where importing a settings file does not properly render the name of the custom font until the settings panel is closed and reopened. The custom font itself is rendered just fine, but the font name in the setting doesn't show up initially. I believe this is such a rare problem that it should be okay for now. 

I found another problem unrelated to this PR. I may put up an issue later, but it relates to how the page sometimes doesn't rescroll when a flow box overruns the bottom of the flow. This issue is caused by the box animation messing with certain browsers' scroll recalculation, but I couldn't find a fix.

I have not tested flow sharing much, but the changes shouldn't affect how nodes are created, so hopefully that isn't affected.

## Problems

1. Icons for importing and exporting settings are needed.
2. The default custom theme that I hardcoded is quite painful to look at in my opinion. I am bad at color design. Improving that could be nice. 
3. The playwright tests fail. I couldn't figure out why. 
4. Some of the variable names are iffy. Specifically `alternativeFlows${number}` , `alternativeFlowSelectorSettingName`, and many of the custom color variables (ex. `customBackgroundAccentSecondaryActive`) are not my favorite. But I couldn't come up with better names.

Let me know what you think of this PR. Also let me know if you would like me to make any changes or explain/document any of the new functions. Thank you for reading this request!

Best,
Jaden