### PR TITLE
Added reference section for all shortcuts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 build
 .vercel
+CODEBASE_INDEX.md
+SHORTCUTS_DATABASE.json
+SHORTCUTS_REFERENCE.md

--- a/src/lib/components/Help.svelte
+++ b/src/lib/components/Help.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { openPopup } from '$lib/models/popup';
 	import { isChangelogVersionCurrent } from '$lib/models/version';
+	import Shortcuts from './Shortcuts.svelte';
 	import Button from './Button.svelte';
 	import Changelog from './Changelog.svelte';
 
@@ -35,6 +36,15 @@
 				target="_blank"
 				tooltip={$isChangelogVersionCurrent ? undefined : 'see new updates'}
 				notification={!$isChangelogVersionCurrent}
+			/>
+			<Button
+				icon = "keyboard"
+				text = "shortcuts"
+				on:click={() => {
+					closePopup();
+					openPopup(Shortcuts, 'Shortcuts');
+				}}
+				target="_blank"
 			/>
 		</ul>
 	</section>

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -245,9 +245,9 @@
 			svg: `<rect x="8" y="24" width="84" height="55" rx="8" stroke-width="10"/>
 <path d="M22 46H78" stroke-width="7" stroke-linecap="round"/>
 <path d="M34 60H66" stroke-width="7" stroke-linecap="round"/>
-<path d="M36 34L36 46" stroke-width="7" stroke-linecap="round"/>
-<path d="M54 34L54 46" stroke-width="7" stroke-linecap="round"/>
-<path d="M72 34L72 46" stroke-width="7" stroke-linecap="round"/>`
+<path d="M30 34L30 46" stroke-width="7" stroke-linecap="round"/>
+<path d="M50 34L50 46" stroke-width="7" stroke-linecap="round"/>
+<path d="M70 34L70 46" stroke-width="7" stroke-linecap="round"/>`
 		}
 	];
 	let displayIcon: { name: string; svg: string } | null;

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -239,6 +239,15 @@
 <line x1="55" y1="50" x2="90" y2="50" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
 <path d="M69 73L95 50L69 27" stroke="currentColor" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M37.5 62C44.4036 62 50 56.4036 50 49.5C50 42.5964 44.4036 37 37.5 37C30.5964 37 25 42.5964 25 49.5C25 56.4036 30.5964 62 37.5 62Z" stroke="currentColor" stroke-width="10"/>`
+		},
+		{
+			name: 'keyboard',
+			svg: `<rect x="8" y="24" width="84" height="55" rx="8" stroke-width="10"/>
+<path d="M22 46H78" stroke-width="7" stroke-linecap="round"/>
+<path d="M34 60H66" stroke-width="7" stroke-linecap="round"/>
+<path d="M36 34L36 46" stroke-width="7" stroke-linecap="round"/>
+<path d="M54 34L54 46" stroke-width="7" stroke-linecap="round"/>
+<path d="M72 34L72 46" stroke-width="7" stroke-linecap="round"/>`
 		}
 	];
 	let displayIcon: { name: string; svg: string } | null;

--- a/src/lib/components/Shortcuts.svelte
+++ b/src/lib/components/Shortcuts.svelte
@@ -23,57 +23,52 @@
 				{ keys: ['commandControl', 'shift', 'n'], description: 'Create new secondary flow' },
 				{ keys: ['commandControl', 'z'], description: 'Undo' },
 				{ keys: ['commandControl', 'shift', 'z'], description: 'Redo' },
-				{ keys: ['commandControl', 'option', 'up'], description: 'Switch to previous tab', note: 'Multiple flows open' },
-				{ keys: ['commandControl', 'option', 'down'], description: 'Switch to next tab', note: 'Multiple flows open' }
+				{ keys: ['commandControl', 'option', 'up'], description: 'Switch to previous tab', note: 'Only when multiple flows open' },
+				{ keys: ['commandControl', 'option', 'down'], description: 'Switch to next tab', note: 'Only when multiple flows open' }
 			]
 		},
 		{
 			name: 'Navigation',
-			context: 'When an argument box is focused',
+			context: 'When a cell is focused',
 			shortcuts: [
-				{ keys: ['up'], description: 'Focus argument above' },
-				{ keys: ['down'], description: 'Focus argument below' },
-				{ keys: ['left'], description: 'Move to parent argument' },
+				{ keys: ['up'], description: 'Focus cell above' },
+				{ keys: ['down'], description: 'Focus cell below' },
+				{ keys: ['left'], description: 'Move to parent cell' },
 				{ keys: ['right'], description: 'Move to first child / response' },
-				{ keys: ['tab'], description: 'Focus next sibling argument' },
-				{ keys: ['shift', 'tab'], description: 'Focus previous sibling argument' }
+				{ keys: ['tab'], description: 'Focus next sibling cell' },
+				{ keys: ['shift', 'tab'], description: 'Focus previous sibling cell' }
 			]
 		},
 		{
-			name: 'Editing',
-			context: 'When an argument box is focused',
+			name: 'Cell Creation',
+			context: 'When a cell is focused',
 			shortcuts: [
-				{ keys: ['return'], description: 'Add argument below' },
-				{ keys: ['shift', 'return'], description: 'Add response (child argument)' },
-				{ keys: ['option', 'return'], description: 'Add argument above', note: 'Not available on extensions' },
+				{ keys: ['return'], description: 'Add cell below' },
+				{ keys: ['shift', 'return'], description: 'Add response (child cell)' },
+				{ keys: ['option', 'return'], description: 'Add cell above', note: 'Not available on extension cells' },
 				{ keys: ['option', 'shift', 'return'], description: "Add at parent's next sibling" }
 			]
 		},
 		{
-			name: 'Formatting',
-			context: 'When an argument box is focused',
+			name: 'Cell Manipulation',
+			context: 'When a cell is focused',
 			shortcuts: [
-				{ keys: ['commandControl', 'b'], description: 'Toggle bold', note: 'Not available on extensions' },
-				{ keys: ['commandControl', 'shift', 'x'], description: 'Toggle crossed out', note: 'Not available on extensions' },
-				{ keys: ['control', 'l'], description: 'Fold / collapse argument', note: 'Only when box has children' }
+				{ keys: ['commandControl', 'b'], description: 'Toggle bold', note: 'Not available on extension cells' },
+				{ keys: ['commandControl', 'shift', 'x'], description: 'Toggle crossed out', note: 'Not available on extension cells' },
+				{ keys: ['control', 'l'], description: 'Fold / collapse cell', note: 'Only when cell has children' },
+				{ keys: ['commandControl', 'e'], description: 'Extend cell', note: 'Not available on extension cells' },
+				{ keys: ['backspace'], description: 'Delete cell', note: 'Only when empty and has no children' },
+				{ keys: ['commandControl', 'backspace'], description: 'Force delete cell', note: 'Only when cell has no children' }
 			]
 		},
-		{
-			name: 'Manipulation',
-			context: 'When an argument box is focused',
-			shortcuts: [
-				{ keys: ['commandControl', 'e'], description: 'Extend argument', note: 'Not available on extensions' },
-				{ keys: ['backspace'], description: 'Delete box', note: 'Only when empty and has no children' },
-				{ keys: ['commandControl', 'backspace'], description: 'Force delete box', note: 'Only when box has no children' }
-			]
-		},
+
 		{
 			name: 'Title',
 			context: 'When editing the flow title',
 			shortcuts: [
-				{ keys: ['return'], description: 'Move focus to first argument' },
-				{ keys: ['down'], description: 'Move focus to first argument' },
-				{ keys: ['right'], description: 'Move focus to first argument' }
+				{ keys: ['return'], description: 'Move focus to first cell' },
+				{ keys: ['down'], description: 'Move focus to first cell' },
+				{ keys: ['right'], description: 'Move focus to first cell' }
 			]
 		}
 	];
@@ -131,7 +126,7 @@
 		display: grid;
 		grid-template-columns: calc(max(130px, 20%) + var(--padding-big)) 1fr;
 	}
-
+	
 	.outline {
 		width: 100%;
 		padding-top: calc(var(--button-size) + var(--padding) * 2);
@@ -227,7 +222,6 @@
 		align-items: center;
 		gap: var(--padding-big);
 		padding: var(--padding) 0;
-		border-top: 1px solid var(--background-indent);
 	}
 
 	.keys {

--- a/src/lib/components/Shortcuts.svelte
+++ b/src/lib/components/Shortcuts.svelte
@@ -1,0 +1,282 @@
+<script lang="ts">
+	import Shortcut from './Shortcut.svelte';
+	import { settings } from '$lib/models/settings';
+
+	type ShortcutEntry = {
+		keys: string[];
+		description: string;
+		note?: string;
+	};
+
+	type ShortcutGroup = {
+		name: string;
+		context: string;
+		shortcuts: ShortcutEntry[];
+	};
+
+	const groups: ShortcutGroup[] = [
+		{
+			name: 'Global',
+			context: 'Available anywhere in the app',
+			shortcuts: [
+				{ keys: ['commandControl', 'n'], description: 'Create new primary flow' },
+				{ keys: ['commandControl', 'shift', 'n'], description: 'Create new secondary flow' },
+				{ keys: ['commandControl', 'z'], description: 'Undo' },
+				{ keys: ['commandControl', 'shift', 'z'], description: 'Redo' },
+				{ keys: ['commandControl', 'option', 'up'], description: 'Switch to previous tab', note: 'Multiple flows open' },
+				{ keys: ['commandControl', 'option', 'down'], description: 'Switch to next tab', note: 'Multiple flows open' }
+			]
+		},
+		{
+			name: 'Navigation',
+			context: 'When an argument box is focused',
+			shortcuts: [
+				{ keys: ['up'], description: 'Focus argument above' },
+				{ keys: ['down'], description: 'Focus argument below' },
+				{ keys: ['left'], description: 'Move to parent argument' },
+				{ keys: ['right'], description: 'Move to first child / response' },
+				{ keys: ['tab'], description: 'Focus next sibling argument' },
+				{ keys: ['shift', 'tab'], description: 'Focus previous sibling argument' }
+			]
+		},
+		{
+			name: 'Editing',
+			context: 'When an argument box is focused',
+			shortcuts: [
+				{ keys: ['return'], description: 'Add argument below' },
+				{ keys: ['shift', 'return'], description: 'Add response (child argument)' },
+				{ keys: ['option', 'return'], description: 'Add argument above', note: 'Not available on extensions' },
+				{ keys: ['option', 'shift', 'return'], description: "Add at parent's next sibling" }
+			]
+		},
+		{
+			name: 'Formatting',
+			context: 'When an argument box is focused',
+			shortcuts: [
+				{ keys: ['commandControl', 'b'], description: 'Toggle bold', note: 'Not available on extensions' },
+				{ keys: ['commandControl', 'shift', 'x'], description: 'Toggle crossed out', note: 'Not available on extensions' },
+				{ keys: ['control', 'l'], description: 'Fold / collapse argument', note: 'Only when box has children' }
+			]
+		},
+		{
+			name: 'Manipulation',
+			context: 'When an argument box is focused',
+			shortcuts: [
+				{ keys: ['commandControl', 'e'], description: 'Extend argument', note: 'Not available on extensions' },
+				{ keys: ['backspace'], description: 'Delete box', note: 'Only when empty and has no children' },
+				{ keys: ['commandControl', 'backspace'], description: 'Force delete box', note: 'Only when box has no children' }
+			]
+		},
+		{
+			name: 'Title',
+			context: 'When editing the flow title',
+			shortcuts: [
+				{ keys: ['return'], description: 'Move focus to first argument' },
+				{ keys: ['down'], description: 'Move focus to first argument' },
+				{ keys: ['right'], description: 'Move focus to first argument' }
+			]
+		}
+	];
+
+	let groupHeaderElements: HTMLElement[] = new Array(groups.length);
+
+	function scrollToGroup(index: number) {
+		groupHeaderElements[index]?.scrollIntoView();
+	}
+</script>
+
+<div class="top palette-plain">
+	<div class="outline">
+		<div class="outlineScroll" class:customScrollbar={settings.data.customScrollbar.value}>
+			<ul>
+				{#each groups as group, i}
+					<li>
+						<button on:click={() => scrollToGroup(i)}>
+							{group.name}
+						</button>
+					</li>
+				{/each}
+			</ul>
+		</div>
+	</div>
+	<div class="content" class:customScrollbar={settings.data.customScrollbar.value}>
+		<ul class="shortcut-list">
+			{#each groups as group, i}
+				<li class="group-header" bind:this={groupHeaderElements[i]}>
+					<h1>{group.name}</h1>
+					<p class="context">{group.context}</p>
+				</li>
+				{#each group.shortcuts as shortcut}
+					<li class="shortcut-row">
+						<div class="keys">
+							<Shortcut keys={shortcut.keys} />
+						</div>
+						<div class="label">
+							<span class="description">{shortcut.description}</span>
+							{#if shortcut.note}
+								<span class="note">{shortcut.note}</span>
+							{/if}
+						</div>
+					</li>
+				{/each}
+			{/each}
+		</ul>
+	</div>
+</div>
+
+<style>
+	.top {
+		width: min(calc(100vw - var(--padding) * 2), 700px);
+		height: min(calc(100vh - var(--padding) * 2), 600px);
+		display: grid;
+		grid-template-columns: calc(max(130px, 20%) + var(--padding-big)) 1fr;
+	}
+
+	.outline {
+		width: 100%;
+		padding-top: calc(var(--button-size) + var(--padding) * 2);
+		box-sizing: border-box;
+		background-color: var(--background-secondary);
+		overflow: hidden;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.outlineScroll {
+		overflow: auto;
+		height: 100%;
+		padding: 0 var(--padding);
+	}
+
+	.outlineScroll ul {
+		padding-bottom: 50vh;
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	.outline button {
+		border: none;
+		background: none;
+		display: block;
+		width: 100%;
+		text-align: left;
+		border-radius: var(--border-radius);
+		color: var(--this-text);
+		padding: var(--padding);
+		overflow-wrap: break-word;
+		transition: background var(--transition-speed);
+		font-weight: var(--font-weight-bold);
+		margin-top: var(--padding);
+		cursor: pointer;
+	}
+
+	.outline button:hover {
+		background-color: var(--this-background-indent);
+	}
+
+	.outline button:active {
+		transition: none;
+		background-color: var(--this-background-active);
+	}
+
+	.content {
+		box-sizing: border-box;
+		width: 100%;
+		padding-top: calc(var(--button-size) + var(--padding));
+		overflow: auto;
+		scroll-behavior: smooth;
+		height: inherit;
+	}
+
+	.shortcut-list {
+		list-style: none;
+		margin: 0;
+		padding: 0 var(--padding-big);
+		padding-bottom: 50vh;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.group-header {
+		display: flex;
+		flex-direction: row;
+		align-items: baseline;
+		gap: var(--padding);
+		padding: calc(var(--padding-big) * 1.5) 0 var(--padding) 0;
+	}
+
+	.group-header:first-child {
+		padding-top: var(--padding-big);
+	}
+
+	.group-header h1 {
+		font-weight: var(--font-weight-bold);
+		margin: 0;
+	}
+
+	.group-header p.context {
+		color: var(--this-text-weak);
+		margin: 0;
+		font-size: 0.85em;
+	}
+
+	.shortcut-row {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		gap: var(--padding-big);
+		padding: var(--padding) 0;
+		border-top: 1px solid var(--background-indent);
+	}
+
+	.keys {
+		min-width: 9rem;
+		flex-shrink: 0;
+	}
+
+	.label {
+		display: flex;
+		flex-direction: column;
+		gap: 0.2em;
+	}
+
+	.description {
+		font-size: 0.9em;
+	}
+
+	.note {
+		font-size: 0.8em;
+		color: var(--this-text-weak);
+	}
+
+	@media (max-width: 600px) {
+		.top {
+			grid-template-columns: 1fr;
+			grid-template-rows: auto 1fr;
+		}
+
+		.outline {
+			padding-top: calc(var(--button-size) + var(--padding) * 2);
+			height: auto;
+		}
+
+		.outlineScroll {
+			height: auto;
+			max-height: 8rem;
+		}
+
+		.outlineScroll ul {
+			display: flex;
+			flex-direction: row;
+			flex-wrap: wrap;
+			gap: var(--padding-small);
+			padding: var(--padding);
+		}
+
+		.outline button {
+			margin-top: 0;
+			width: auto;
+		}
+	}
+</style>

--- a/src/lib/models/key.ts
+++ b/src/lib/models/key.ts
@@ -39,6 +39,7 @@ export const keyDict: {
 	return: '↵',
 	space: 'space',
 	delete: 'delete',
+	backspace: 'backspace',
 	tab: 'tab'
 };
 

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -20,6 +20,7 @@
 	import { loadNodes, importSettingsJson } from '$lib/models/file';
 	import Timers from '$lib/components/Timers.svelte';
 	import Help from '$lib/components/Help.svelte';
+	import Shortcuts from '$lib/components/Shortcuts.svelte';
 	import { settings } from '$lib/models/settings';
 	import SideDoc from '$lib/components/SideDoc.svelte';
 	import { history } from '$lib/models/history';
@@ -344,6 +345,11 @@
 							onclick: () => openPopup(Share, 'Share'),
 							tooltip: 'share',
 							tutorialHighlight: 4
+						},
+						{
+							icon: 'keyboard',
+							onclick: () => openPopup(Shortcuts, 'Shortcuts'),
+							tooltip: 'keyboard shortcuts'
 						}
 					]}
 				/>

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -346,11 +346,6 @@
 							tooltip: 'share',
 							tutorialHighlight: 4
 						},
-						{
-							icon: 'keyboard',
-							onclick: () => openPopup(Shortcuts, 'Shortcuts'),
-							tooltip: 'keyboard shortcuts'
-						}
 					]}
 				/>
 			</div>


### PR DESCRIPTION
## Add Keyboard Shortcuts Reference Popup

### Summary
I love this platform as a policy debater, but I would love it more if I knew all the cool shortcuts. I added a pop-up component in the top-left corner that lists all shortcuts in a clean, organized format consistent with the site's UI. 

### Changes Made

- Created a new **`Shortcuts.svelte`** component  
- Displays a structured list of all keyboard shortcuts  
- Opens in a clean pop-up UI

- Added a **keyboard icon** to `Icon.svelte` for launching the shortcuts panel  

- added backspace to the key dict 

- added it all into page with on-click 


### Testing

- Verified popup opens correctly when clicking keyboard icon  
- Confirmed all shortcuts render properly  
- Checked no UI breakage across pages where component was added  

---


## Three Dots (more section)

<img width="330" height="195" alt="image" src="https://github.com/user-attachments/assets/f2322478-41ec-4e7a-97f8-6884b20ba4f8" />




## Image of popup shortcut reference

<img width="845" height="759" alt="image" src="https://github.com/user-attachments/assets/f9d3682c-dff2-4163-a939-1ace2b9c6353" />


This site is super cool lmk edits
